### PR TITLE
Better test for color-capable TERM

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text eol=lf
 *.ico binary
+*.png binary
 
 # Custom for Visual Studio
 *.cs     diff=csharp

--- a/lib/UI/Color.sh
+++ b/lib/UI/Color.sh
@@ -1,4 +1,4 @@
-alias UI.Color.IsAvailable='[[ "${TERM}" == *"xterm"* ]] && [ -t 1 ]'
+alias UI.Color.IsAvailable='[ $(tput colors 2>/dev/null || echo 0) -ge 16 ] && [ -t 1 ]'
 if UI.Color.IsAvailable
 then
   alias UI.Color.Default="echo \$'\033[0m'"


### PR DESCRIPTION
This works much better for me.  Tested on OS X 10.10, Amazon AMI, and some various other servers I have running.

The list of available terminals that support 16 or more colors is pretty significant, and this prevents having to match on all of 'em:
```
#!/usr/bin/env bash

source "$( cd "${BASH_SOURCE[0]%/*}" && pwd )/lib/oo-bootstrap.sh"

import util/log

namespace test_color
Log::AddOutput test_color INFO

for termfile in $(find /usr/share/terminfo/ -type f); do
  termtyp=$(basename $termfile)
  export TERM=$termtyp
  UI.Color.IsAvailable && Log "$termtyp supports $(tput colors) colors"
done
```