### PR TITLE
Add chromiumos color support

### DIFF
--- a/lib/UI/Color.sh
+++ b/lib/UI/Color.sh
@@ -1,5 +1,5 @@
 alias UI.Color.IsAvailable='[ $(tput colors 2>/dev/null || echo 0) -ge 16 ] && [ -t 1 ]'
-if UI.Color.IsAvailable
+if [ UI.Color.IsAvailable ] || [ grep -Fxq "ID_LIKE=chromiumos" /etc/os-release ]
 then
   alias UI.Color.Default="echo \$'\033[0m'"
 


### PR DESCRIPTION
This will enable color support for Chromium OS. If there are more platform where such a way is neccessary, another approach might be needed.

Before, colors were not enabled on Chromium OS, although it supports them.