### PR TITLE
Uses first element of BASH_SOURCE in PS4 prompt

### DIFF
--- a/lib/oo-bootstrap.sh
+++ b/lib/oo-bootstrap.sh
@@ -166,7 +166,7 @@ System::Bootstrap() {
 ########################
 
 # From: http://wiki.bash-hackers.org/scripting/debuggingtips
-export PS4='+(${BASH_SOURCE[1]##*/}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+export PS4='+(${BASH_SOURCE##*/}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # Bash will remember & return the highest exitcode in a chain of pipes.
 # This way you can catch the error inside pipes, e.g. mysqldump | gzip


### PR DESCRIPTION
In `lib/oo-bootstrap.sh`, line 169 reads:

`export PS4='+(${BASH_SOURCE[1]##*/}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'`

I have the following structure in one of my scripts:
```
. "$PROJECT_DIR/scripts/vendor/bash-oo-framework/lib/oo-bootstrap.sh"
. "$PROJECT_DIR/scripts/common/lib.sh"
. "$PROJECT_DIR/scripts/common/vars.sh"
```
In `lib.sh` I `set -e`. This causes the PS4 to cause an error when it needs to be printed and my script to exit. 

Moreover, it is counter-intuitive to include ${BASH_SOURCE[1]} in PS4 even when it exists, as it makes tracking of the code harder by pointing to one level up. Thus, you have to eg go to the file that is returned by PS4, try to find what was the last actual call from that file, see that it calls a function, then try to locate the file containing the file definition, go to the line mentioned in PS4 and see what is causing the error. PS4 should show the actual file that contains the printed line at the lineno shown in PS4. 