### PR TITLE
Remove 'i/s' options from __oo__presetShellOpts in try command

### DIFF
--- a/lib/util/tryCatch.sh
+++ b/lib/util/tryCatch.sh
@@ -3,7 +3,7 @@ declare -ig __oo__insideTryCatch=0
 declare -g __oo__presetShellOpts="$-"
 
 # in case try-catch is nested, we set +e before so the parent handler doesn't catch us instead
-alias try='[[ $__oo__insideTryCatch -eq 0 ]] || __oo__presetShellOpts="$-"; __oo__insideTryCatch+=1; set +e; ( set -e; true; '
+alias try='[[ $__oo__insideTryCatch -eq 0 ]] || __oo__presetShellOpts="$(echo $- | sed 's/[is]//g')"; __oo__insideTryCatch+=1; set +e; ( set -e; true; '
 alias catch='); declare __oo__tryResult=$?; __oo__insideTryCatch+=-1; [[ $__oo__insideTryCatch -lt 1 ]] || set -${__oo__presetShellOpts:-e} && Exception::Extract $__oo__tryResult || '
 
 Exception::SetupTemp() {


### PR DESCRIPTION
`set -i`/`set -s` are no longer valid so that I delete them.
When I use my script which use tryCatch by sourcing, an error has occured because of this.
I'm sure this way of executing (by sourcing scripts) is not common. I do while testing and developing.
Anyway, as we don't need those two options, I decided to delete them.


This is what I've got before this change(`blib::install` is my command defined in blib.oo.sh):

```bash
<X_X>:blib$ source ./blib.oo.sh
$?is0
<X_X>:blib$ blib::install Cj-bc/libtar
bash: set: -i: invalid option
set: usage: set [-abefhkmnptuvxBCHP] [-o option-name] [--] [arg ...]
```