### PR TITLE
Feature: Add exits.sh -- list of exit codes

### DIFF
--- a/lib/util/exits.sh
+++ b/lib/util/exits.sh
@@ -6,19 +6,19 @@
 #
 
 # successful termination
-EX_OK=0
-EX_USAGE=64  # command line usage error
-EX_DATAERR=65  # data format error
-EX_NOINPUT=66  # cannot open input
-EX_NOUSER=67  # addressee unknown
-EX_NOHOST=68  # host name unknown
-EX_UNAVAILABLE=69  # service unavailable
-EX_SOFTWARE=70  # internal software error
-EX_OSERR=71  # system error (e.g., can't fork)
-EX_OSFILE=72  # critical OS file missing
-EX_CANTCREAT=73  # can't create (user) output file
-EX_IOERR=74  # input/output error
-EX_TEMPFAIL=75  # temp failure; user is invited to retry
-EX_PROTOCOL=76  # remote error in protocol
-EX_NOPERM=77  # permission denied
-EX_CONFIG=78  # configuration error
+Util_ExitCode_OK=0
+Util_ExitCode_USAGE=64  # command line usage error
+Util_ExitCode_DATAERR=65  # data format error
+Util_ExitCode_NOINPUT=66  # cannot open input
+Util_ExitCode_NOUSER=67  # addressee unknown
+Util_ExitCode_NOHOST=68  # host name unknown
+Util_ExitCode_UNAVAILABLE=69  # service unavailable
+Util_ExitCode_SOFTWARE=70  # internal software error
+Util_ExitCode_OSERR=71  # system error (e.g., can't fork)
+Util_ExitCode_OSFILE=72  # critical OS file missing
+Util_ExitCode_CANTCREAT=73  # can't create (user) output file
+Util_ExitCode_IOERR=74  # input/output error
+Util_ExitCode_TEMPFAIL=75  # temp failure; user is invited to retry
+Util_ExitCode_PROTOCOL=76  # remote error in protocol
+Util_ExitCode_NOPERM=77  # permission denied
+Util_ExitCode_CONFIG=78  # configuration error

--- a/lib/util/exits.sh
+++ b/lib/util/exits.sh
@@ -22,4 +22,3 @@ EX_TEMPFAIL=75  # temp failure; user is invited to retry
 EX_PROTOCOL=76  # remote error in protocol
 EX_NOPERM=77  # permission denied
 EX_CONFIG=78  # configuration error
-EX__MAX=78  # maximum listed value

--- a/lib/util/exits.sh
+++ b/lib/util/exits.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# exits
+#
+# Those values are come from /usr/include/sysexits.h
+#
+
+# successful termination
+EX_OK=0
+EX_USAGE=64  # command line usage error
+EX_DATAERR=65  # data format error
+EX_NOINPUT=66  # cannot open input
+EX_NOUSER=67  # addressee unknown
+EX_NOHOST=68  # host name unknown
+EX_UNAVAILABLE=69  # service unavailable
+EX_SOFTWARE=70  # internal software error
+EX_OSERR=71  # system error (e.g., can't fork)
+EX_OSFILE=72  # critical OS file missing
+EX_CANTCREAT=73  # can't create (user) output file
+EX_IOERR=74  # input/output error
+EX_TEMPFAIL=75  # temp failure; user is invited to retry
+EX_PROTOCOL=76  # remote error in protocol
+EX_NOPERM=77  # permission denied
+EX_CONFIG=78  # configuration error
+EX__MAX=78  # maximum listed value


### PR DESCRIPTION
In some shellscript coding guide, I found that we should follow `/usr/include/sysexits.h` to define exit code.
So I added list of those exit codes as variables.

Those values are come from /usr/include/sysexits.h