### PR TITLE
feat(dotenv): autoload .env files

### DIFF
--- a/lib/util/dotenv.sh
+++ b/lib/util/dotenv.sh
@@ -1,0 +1,10 @@
+dotenv () {
+  envfile="${1:-$(pwd)}/.env"
+
+  if [[ -f "$envfile" ]]
+  then
+    export $(egrep -v '^#' "$envfile" | xargs)
+  fi
+}
+
+dotenv


### PR DESCRIPTION
Automatically load `.env` files from the current working directory:

```bash
import util/dotenv
```

It can be called to load additional files, e.g.

```bash
dotenv /path/to/private/.env
```