### PR TITLE
Added Travis-CI and Cirrus-CI builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,12 @@
-container:
-  image: gcc:latest
 test_task:
-  check_env_script:
-    - apt-cache policy bash
-  test_script: 
-    - bash --version
+  container:
+    matrix:
+      image: bash:5
+      image: bash:4
+    cpu: 1
+    memory: 512M
+  version_script: bash --version
+  test_script:
     - cd example
     - ./array.sh  
     - ./human.sh  

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,8 +1,12 @@
 test_task:
   container:
     matrix:
-      image: bash:5
-      image: bash:4
+      # version numbers found on https://hub.docker.com/_/bash
+      image: bash:latest
+      image: bash:5.0.3
+      image: bash:4.4.23
+      image: bash:4.3.48
+      image: bash:4.2.53
     cpu: 1
     memory: 512M
   version_script: bash --version

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,13 @@
+container:
+  image: gcc:latest
+test_task:
+  check_env_script:
+    - apt-cache policy bash
+  test_script: 
+    - bash --version
+    - cd example
+    - ./array.sh  
+    - ./human.sh  
+    - ./string.sh  
+    - ./testing.sh
+    - ./trycatch.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,17 @@
-# upgrade to bash 4.4
-install:
-  - apt-cache policy bash gcc make
-  - bash --version
-  # install gcc and make
-  - sudo apt-get -y install build-essential
-  - gcc -v
-  - make -v
-  - wget http://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz
-  - tar xf bash-4.4.tar.gz
-  - cd bash-4.4
-  - ./configure
-  - make
-  - cd ..
-  - export PATH=$PWD/bash-4.4:$PATH
-  - bash --version
+language: bash
 
-# run examples
+env:
+  - BASH=latest
+  - BASH=5.0.3
+  - BASH=4.4.23
+  - BASH=4.3.48
+  - BASH=4.2.53
+before_script: 
+  - docker pull bash:$BASH
+  - docker run bash --version
 script:
-  - cd example
-  - ./array.sh  
-  - ./human.sh  
-  - ./string.sh  
-  #- ./testing.sh  hanging
-  #- ./trycatch.sh hanging
+  - docker run -v $PWD:/bash bash bash/example/array.sh
+  - docker run -v $PWD:/bash bash bash/example/human.sh
+  - docker run -v $PWD:/bash bash bash/example/string.sh
+  - docker run -v $PWD:/bash bash bash/example/testing.sh
+  - docker run -v $PWD:/bash bash bash/example/trycatch.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+script:
+  - cd example
+  - for f in *.sh; do ./$f; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 script:
   - cd example
-  - for f in *.sh; do ./$f; done
+  #- for f in *.sh; do ./$f; done
+  - ./array.sh  
+  - ./human.sh  
+  - ./string.sh  
+  - ./testing.sh  
+  - ./trycatch.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+# upgrade to bash 4.4
 install:
   - apt-cache policy bash gcc make
   - bash --version
-  - sudo apt-get -y bash install build-essential
-  - bash --version
+  # install gcc and make
+  - sudo apt-get -y install build-essential
   - gcc -v
   - make -v
   - wget http://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz
@@ -13,11 +14,12 @@ install:
   - cd ..
   - export PATH=$PWD/bash-4.4:$PATH
   - bash --version
+
+# run examples
 script:
   - cd example
-  #- for f in *.sh; do ./$f; done
   - ./array.sh  
   - ./human.sh  
   - ./string.sh  
-  #- ./testing.sh  
+  #- ./testing.sh  hanging
   - ./trycatch.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   - ./human.sh  
   - ./string.sh  
   #- ./testing.sh  hanging
-  - ./trycatch.sh
+  #- ./trycatch.sh hanging

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 script:
+  - bash --version
   - cd example
   #- for f in *.sh; do ./$f; done
-  - ./array.sh  
+  #- ./array.sh  
   - ./human.sh  
   - ./string.sh  
   - ./testing.sh  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,23 @@
-script:
+install:
   - bash --version
+  - gcc -v || echo ignore
+  - make -v || echo ignore
+  - sudo apt-get -y install build-essential
+  - gcc -v
+  - make -v
+  - wget http://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz
+  - tar xf bash-4.4.tar.gz
+  - cd bash-4.4
+  - ./configure
+  - make
+  - cd ..
+  - export PATH=$PWD/bash-4.4:$PATH
+  - bash --version
+script:
   - cd example
   #- for f in *.sh; do ./$f; done
-  #- ./array.sh  
-  - ./human.sh  
+  - ../bash-4.4/bash ./array.sh  
+  - bash ./human.sh  
   - ./string.sh  
   - ./testing.sh  
   - ./trycatch.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 install:
+  - apt-cache policy bash gcc make
   - bash --version
-  - gcc -v || echo ignore
-  - make -v || echo ignore
-  - sudo apt-get -y install build-essential
+  - sudo apt-get -y bash install build-essential
+  - bash --version
   - gcc -v
   - make -v
   - wget http://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz
@@ -16,8 +16,8 @@ install:
 script:
   - cd example
   #- for f in *.sh; do ./$f; done
-  - ../bash-4.4/bash ./array.sh  
-  - bash ./human.sh  
+  - ./array.sh  
+  - ./human.sh  
   - ./string.sh  
-  - ./testing.sh  
+  #- ./testing.sh  
   - ./trycatch.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ env:
   - BASH=4.2.53
 before_script: 
   - docker pull bash:$BASH
-  - docker run bash --version
+  - docker run bash:$BASH --version
 script:
-  - docker run -v $PWD:/bash bash bash/example/array.sh
-  - docker run -v $PWD:/bash bash bash/example/human.sh
-  - docker run -v $PWD:/bash bash bash/example/string.sh
-  - docker run -v $PWD:/bash bash bash/example/testing.sh
-  - docker run -v $PWD:/bash bash bash/example/trycatch.sh
+  - docker run -v $PWD:/bash bash:$BASH bash/example/array.sh
+  - docker run -v $PWD:/bash bash:$BASH bash/example/human.sh
+  - docker run -v $PWD:/bash bash:$BASH bash/example/string.sh
+  - docker run -v $PWD:/bash bash:$BASH bash/example/testing.sh
+  - docker run -v $PWD:/bash bash:$BASH bash/example/trycatch.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Bash Infinity
 =============
 [![Build Status](https://travis-ci.com/niieani/bash-oo-framework.svg?branch=master)](https://travis-ci.com/niieani/bash-oo-framework)
+[![Build Status](https://api.cirrus-ci.com/github/niieani/bash-oo-framework.svg)](https://cirrus-ci.com/github/niieani/bash-oo-framework)
 [![Join the chat at https://gitter.im/niieani/bash-oo-framework](https://badges.gitter.im/niieani/bash-oo-framework.svg)](https://gitter.im/niieani/bash-oo-framework?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Bash Infinity is a standard library and a boilerplate framework for writing tools using **bash**.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Bash Infinity
 =============
-
+[![Build Status](https://travis-ci.com/niieani/bash-oo-framework.svg?branch=master)](https://travis-ci.com/niieani/bash-oo-framework)
 [![Join the chat at https://gitter.im/niieani/bash-oo-framework](https://badges.gitter.im/niieani/bash-oo-framework.svg)](https://gitter.im/niieani/bash-oo-framework?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Bash Infinity is a standard library and a boilerplate framework for writing tools using **bash**.


### PR DESCRIPTION
Since examples are dependent on version of bash, I installed bash 4.4.

It's pretty easy to configure Travis to run examples against a matrix of bash versions if necessary in future.
